### PR TITLE
Multiple tasks

### DIFF
--- a/controller.php
+++ b/controller.php
@@ -2,15 +2,18 @@
 
 namespace Concrete\Package\BrandCentralConnector;
 
+use Concrete\Core\Config\Repository\Repository;
 use Concrete\Core\File\ExternalFileProvider\Type\Type;
+use Concrete\Core\File\Filesystem;
 use Concrete\Core\Package\Package;
 use Concrete\Core\Package\PackageService;
+use Concrete\Core\Tree\Node\Type\FileFolder;
 use Concrete5\BrandCentralConnector\ServiceProvider;
 
 class Controller extends Package
 {
     protected $appVersionRequired = '9.0.0a3';
-    protected $pkgVersion = '0.1.2';
+    protected $pkgVersion = '0.1.3';
     protected $pkgHandle = 'brand_central_connector';
     protected $pkgDescription = '';
     protected $pkgAutoloaderRegistries = ['src' => 'Concrete5\BrandCentralConnector'];
@@ -37,6 +40,19 @@ class Controller extends Package
 
         if (!$externalFileProvider instanceof Type) {
             Type::add('brand_central', t('Brand Central'), $pkg);
+        }
+
+        // Create BrandCentral folder
+        $filesystem = new Filesystem();
+        $folderName = t("BrandCentral");
+        $rootFolder = $filesystem->getRootFolder();
+        $folder = FileFolder::getNodeByName($folderName);
+
+        if (!$folder instanceof FileFolder) {
+            $createdFolder = $filesystem->addFolder($rootFolder, $folderName);
+            /** @var Repository $config */
+            $config = $this->app->make(Repository::class);
+            $config->save("brand_central_connector.target_upload_directory_id", $createdFolder->getTreeNodeID());
         }
     }
 

--- a/controller.php
+++ b/controller.php
@@ -13,7 +13,7 @@ use Concrete5\BrandCentralConnector\ServiceProvider;
 class Controller extends Package
 {
     protected $appVersionRequired = '9.0.0a3';
-    protected $pkgVersion = '0.1.4';
+    protected $pkgVersion = '0.1.6';
     protected $pkgHandle = 'brand_central_connector';
     protected $pkgDescription = '';
     protected $pkgAutoloaderRegistries = ['src' => 'Concrete5\BrandCentralConnector'];
@@ -52,7 +52,7 @@ class Controller extends Package
             $createdFolder = $filesystem->addFolder($rootFolder, $folderName);
             /** @var Repository $config */
             $config = $this->app->make(Repository::class);
-            $config->save("brand_central_connector.target_upload_directory_id", $createdFolder->getTreeNodeID());
+            $config->save("concrete.external_file_providers.preferred_upload_directory_id", $createdFolder->getTreeNodeID());
         }
 
         //Add File Attribute

--- a/controller.php
+++ b/controller.php
@@ -13,7 +13,7 @@ use Concrete5\BrandCentralConnector\ServiceProvider;
 class Controller extends Package
 {
     protected $appVersionRequired = '9.0.0a3';
-    protected $pkgVersion = '0.1.3';
+    protected $pkgVersion = '0.1.4';
     protected $pkgHandle = 'brand_central_connector';
     protected $pkgDescription = '';
     protected $pkgAutoloaderRegistries = ['src' => 'Concrete5\BrandCentralConnector'];
@@ -54,6 +54,9 @@ class Controller extends Package
             $config = $this->app->make(Repository::class);
             $config->save("brand_central_connector.target_upload_directory_id", $createdFolder->getTreeNodeID());
         }
+
+        //Add File Attribute
+        $this->installContentFile("install.xml");
     }
 
     public function upgrade()

--- a/install.xml
+++ b/install.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0"?>
+<concrete5-cif version="1.0">
+    <attributekeys>
+        <attributekey handle="brand_central_asset_file_id" name="BrandCentral Asset File ID" package="" searchable="1"
+                      indexed="0" type="number"
+                      category="file"/>
+    </attributekeys>
+</concrete5-cif>

--- a/js/brand-central-connector.js
+++ b/js/brand-central-connector.js
@@ -6,7 +6,7 @@
             if (data.externalFileProviderTypeHandle === "brand_central") {
                 jQuery.fn.dialog.open({
                     title: data.externalFileProviderName,
-                    href: CCM_DISPATCHER_FILENAME + "/ccm/brand_central_connector/select_asset_file/" + data.externalFileProviderId + "/" + data.selectedFile.fID,
+                    href: CCM_DISPATCHER_FILENAME + "/ccm/brand_central_connector/select_asset_file/" + data.externalFileProviderId + "/" + data.selectedFile.fID + "?externalFileProviderUploadDirectoryId=" + encodeURI(data.externalFileProviderUploadDirectoryId),
                     width: '80%',
                     modal: true,
                     height: '80%',

--- a/src/File/ExternalFileProvider/Configuration/BrandCentralConfiguration.php
+++ b/src/File/ExternalFileProvider/Configuration/BrandCentralConfiguration.php
@@ -205,6 +205,8 @@ class BrandCentralConfiguration extends Configuration implements ConfigurationIn
             $file->setFileFolder($destFolder);
             /** @noinspection PhpUndefinedMethodInspection */
             $file->getFileNodeObject()->move($destFolder);
+
+            $file->setAttribute("brand_central_asset_file_id", $data["assetId"]);
         }
 
         return $fileVersion;

--- a/views/dialogs/brand_central_connector/asset_file_selector.php
+++ b/views/dialogs/brand_central_connector/asset_file_selector.php
@@ -10,6 +10,7 @@ use Concrete5\BrandCentralConnector\AssetDetails;
 
 /** @var int $assetId */
 /** @var int $externalFileProviderId */
+/** @var int $externalFileProviderUploadDirectoryId */
 /** @var AssetDetails $assetDetails */
 
 $app = Application::getFacadeApplication();
@@ -25,6 +26,8 @@ $token = $app->make(Token::class);
     <?php echo $token->output('select_asset_file'); ?>
 
     <?php echo $form->hidden('externalFileProviderId', $externalFileProviderId); ?>
+
+    <?php echo $form->hidden('externalFileProviderUploadDirectoryId', $externalFileProviderUploadDirectoryId); ?>
 
     <div class="row">
         <div class="col-sm-12">


### PR DESCRIPTION

- Change logic: Use the file name from the server instead of parsing the file name of the downloaded file.
- Extend install/upload method: Add a custom file attribute called "BrandCentral Asset File ID" and store the asset id after importing a file through the connector
- Create a "BrandCentral" folder beneath the root folder on install/update if not available and set it as default in the settings
- Set the default upload folder of the vue component to the user's home folder (if available); Otherwise use the "BrandCentral" folder
